### PR TITLE
JWT 로그인 토큰 발급

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application-dev.properties
+src/main/resources/application-prod.properties

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/
 
 src/main/resources/application-dev.properties
 src/main/resources/application-prod.properties
+
+src/main/lib/

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,23 @@
             <artifactId>jjwt-api</artifactId>
             <version>0.12.6</version>
         </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,6 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
@@ -47,6 +43,29 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>annotationProcessor</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/cu2mber/authservice/AuthServiceApplication.java
+++ b/src/main/java/com/cu2mber/authservice/AuthServiceApplication.java
@@ -2,8 +2,10 @@ package com.cu2mber.authservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class AuthServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/cu2mber/authservice/auth/controller/AuthController.java
+++ b/src/main/java/com/cu2mber/authservice/auth/controller/AuthController.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 인증 및 토큰 관리 API
+ */
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -15,17 +18,36 @@ public class AuthController {
 
     private final AuthService authService;
 
-    // 1. 최초 토큰 발급 (member-service가 호출함)
+    /**
+     * 최초 토큰 발급 (로그인 시 사용)
+     * @param request 사용자 번호 및 권한 정보
+     * @return Access & Refresh Token
+     */
     @PostMapping("/issue")
     public ResponseEntity<TokenResponse> issueToken(@RequestBody IssueRequest request) {
-        TokenResponse tokens = authService.createTokens(request.getMemberId(), request.getRole());
+        TokenResponse tokens = authService.createTokens(request.memberNo(), request.role());
         return ResponseEntity.ok(tokens);
     }
 
-    // 2. 리프레시 토큰으로 엑세스 토큰 재발급 (사용자가 직접 호출함)
+    /**
+     * 액세스 토큰 재발급
+     * @param refreshToken 헤더의 리프레시 토큰
+     * @return 새로운 Access Token
+     */
     @PostMapping("/refresh")
     public ResponseEntity<AccessToken> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
         AccessToken newAccessToken = authService.refreshAccessToken(refreshToken);
         return ResponseEntity.ok(newAccessToken);
+    }
+
+    /**
+     * 로그아웃 API
+     * @param refreshToken 헤더로 전달받은 리프레시 토큰
+     * @return 성공 메시지
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestHeader("Refresh-Token") String refreshToken) {
+        authService.logout(refreshToken);
+        return ResponseEntity.ok("로그아웃이 성공적으로 처리되었습니다.");
     }
 }

--- a/src/main/java/com/cu2mber/authservice/auth/controller/AuthController.java
+++ b/src/main/java/com/cu2mber/authservice/auth/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.cu2mber.authservice.auth.controller;
+
+import com.cu2mber.authservice.auth.dto.AccessToken;
+import com.cu2mber.authservice.auth.dto.IssueRequest;
+import com.cu2mber.authservice.auth.dto.TokenResponse;
+import com.cu2mber.authservice.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 1. 최초 토큰 발급 (member-service가 호출함)
+    @PostMapping("/issue")
+    public ResponseEntity<TokenResponse> issueToken(@RequestBody IssueRequest request) {
+        TokenResponse tokens = authService.createTokens(request.getMemberId(), request.getRole());
+        return ResponseEntity.ok(tokens);
+    }
+
+    // 2. 리프레시 토큰으로 엑세스 토큰 재발급 (사용자가 직접 호출함)
+    @PostMapping("/refresh")
+    public ResponseEntity<AccessToken> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        AccessToken newAccessToken = authService.refreshAccessToken(refreshToken);
+        return ResponseEntity.ok(newAccessToken);
+    }
+}

--- a/src/main/java/com/cu2mber/authservice/auth/controller/AuthController.java
+++ b/src/main/java/com/cu2mber/authservice/auth/controller/AuthController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * 인증 및 토큰 관리 API
+ * 인증 및 토큰 관리 API 컨트롤러
  */
 @RestController
 @RequestMapping("/auth")

--- a/src/main/java/com/cu2mber/authservice/auth/domain/RefreshToken.java
+++ b/src/main/java/com/cu2mber/authservice/auth/domain/RefreshToken.java
@@ -33,7 +33,7 @@ public class RefreshToken {
      * <p>서비스 간 결합도를 낮추기 위해 연관관계 매핑 대신 ID 값만 직접 저장합니다.</p>
      */
     @Column(nullable = false, unique = true)
-    Long memberId;
+    Long memberNo;
 
     /**
      * 실제 발급된 JWT 리프레시 토큰 문자열
@@ -47,8 +47,8 @@ public class RefreshToken {
     @Column(nullable = false)
     LocalDateTime expiryDate;
 
-    public RefreshToken(Long memberId, String token, LocalDateTime expiryDate) {
-        this.memberId = memberId;
+    public RefreshToken(Long memberNo, String token, LocalDateTime expiryDate) {
+        this.memberNo = memberNo;
         this.token = token;
         this.expiryDate = expiryDate;
     }

--- a/src/main/java/com/cu2mber/authservice/auth/domain/RefreshToken.java
+++ b/src/main/java/com/cu2mber/authservice/auth/domain/RefreshToken.java
@@ -1,0 +1,60 @@
+package com.cu2mber.authservice.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * JWT 리프레시 토큰 정보를 관리하는 엔티티 클래스입니다.
+ * <p>
+ * 사용자의 고유 식별자와 발급된 리프레시 토큰 값을 매핑하여 저장하며,
+ * 액세스 토큰 만료 시 재발급을 위한 검증 용도로 사용됩니다.
+ * </p>
+ *
+ */
+@Entity
+@Table(name="refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    /**
+     * 리프레시 토큰의 고유 식별자 (Primary Key)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    /**
+     * Member Service에서 관리하는 사용자의 고유 번호
+     * <p>서비스 간 결합도를 낮추기 위해 연관관계 매핑 대신 ID 값만 직접 저장합니다.</p>
+     */
+    @Column(nullable = false, unique = true)
+    Long memberId;
+
+    /**
+     * 실제 발급된 JWT 리프레시 토큰 문자열
+     */
+    @Column(nullable = false, length = 500)
+    private String token;
+
+    /**
+     * 해당 토큰의 만료 일시
+     */
+    @Column(nullable = false)
+    LocalDateTime expiryDate;
+
+    public RefreshToken(Long memberId, String token, LocalDateTime expiryDate) {
+        this.memberId = memberId;
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+
+    public void updateToken(String newToken, LocalDateTime newExpiryDate) {
+        this.token = newToken;
+        this.expiryDate = newExpiryDate;
+    }
+}

--- a/src/main/java/com/cu2mber/authservice/auth/domain/RefreshToken.java
+++ b/src/main/java/com/cu2mber/authservice/auth/domain/RefreshToken.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 /**
- * JWT 리프레시 토큰 정보를 관리하는 엔티티 클래스입니다.
+ * JWT 리프레시 토큰 정보를 관리하는 엔티티 클래스
  * <p>
  * 사용자의 고유 식별자와 발급된 리프레시 토큰 값을 매핑하여 저장하며,
  * 액세스 토큰 만료 시 재발급을 위한 검증 용도로 사용됩니다.

--- a/src/main/java/com/cu2mber/authservice/auth/dto/AccessToken.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/AccessToken.java
@@ -1,0 +1,4 @@
+package com.cu2mber.authservice.auth.dto;
+
+public record AccessToken(String accessToken) {
+}

--- a/src/main/java/com/cu2mber/authservice/auth/dto/AccessToken.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/AccessToken.java
@@ -1,4 +1,8 @@
 package com.cu2mber.authservice.auth.dto;
 
+/**
+ * 액세스 토큰 재발급 시 반환되는 응답 DTO
+ * * @param accessToken 새롭게 생성된 액세스 토큰
+ */
 public record AccessToken(String accessToken) {
 }

--- a/src/main/java/com/cu2mber/authservice/auth/dto/IssueRequest.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/IssueRequest.java
@@ -1,0 +1,4 @@
+package com.cu2mber.authservice.auth.dto;
+
+public record IssueRequest(Long memberId, String role) {
+}

--- a/src/main/java/com/cu2mber/authservice/auth/dto/IssueRequest.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/IssueRequest.java
@@ -1,4 +1,9 @@
 package com.cu2mber.authservice.auth.dto;
 
+/**
+ * 토큰 발급 요청을 위한 DTO
+ * * @param memberNo 사용자 고유 번호
+ * @param role     사용자에게 부여될 권한 (예: ROLE_USER)
+ */
 public record IssueRequest(Long memberNo, String role) {
 }

--- a/src/main/java/com/cu2mber/authservice/auth/dto/IssueRequest.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/IssueRequest.java
@@ -1,4 +1,4 @@
 package com.cu2mber.authservice.auth.dto;
 
-public record IssueRequest(Long memberId, String role) {
+public record IssueRequest(Long memberNo, String role) {
 }

--- a/src/main/java/com/cu2mber/authservice/auth/dto/TokenResponse.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/TokenResponse.java
@@ -1,4 +1,9 @@
 package com.cu2mber.authservice.auth.dto;
 
+/**
+ * 토큰 발급 성공 시 반환되는 응답 DTO
+ * * @param accessToken  리소스 접근을 위한 액세스 토큰
+ * @param refreshToken 액세스 토큰 만료 시 재발급을 위한 리프레시 토큰
+ */
 public record TokenResponse(String accessToken, String refreshToken) {
 }

--- a/src/main/java/com/cu2mber/authservice/auth/dto/TokenResponse.java
+++ b/src/main/java/com/cu2mber/authservice/auth/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.cu2mber.authservice.auth.dto;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/cu2mber/authservice/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/cu2mber/authservice/auth/repository/RefreshTokenRepository.java
@@ -10,6 +10,10 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+/**
+ * RefreshToken 엔티티에 대한 데이터 액세스 처리를 담당하는 레포지토리
+ * <p>사용자별 토큰 관리 및 만료된 토큰의 일괄 삭제 기능을 제공합니다.</p>
+ */
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     /**
@@ -19,12 +23,12 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     /**
      * 토큰 문자열(String)로 토큰 정보 조회
-     * 사용자가 헤더에 담아 보낸 '문자열'과 DB의 '문자열'을 비교
+     * <p>사용자가 헤더에 담아 보낸 '문자열'과 DB의 '문자열'을 비교합니다.</p>
      */
     Optional<RefreshToken> findByToken(String token);
 
     /**
-     * 특정 일시보다 이전(Before)인 만료 시간을 가진 토큰을 일괄 삭제합니다.
+     * 특정 일시보다 이전(Before)인 만료 시간을 가진 토큰 일괄 삭제
      * @param now 현재 시간
      */
     @Modifying

--- a/src/main/java/com/cu2mber/authservice/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/cu2mber/authservice/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,34 @@
+package com.cu2mber.authservice.auth.repository;
+
+import com.cu2mber.authservice.auth.domain.RefreshToken;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    /**
+     * 사용자 번호로 토큰 정보 조회
+     */
+    Optional<RefreshToken> findByMemberNo(Long memberNo);
+
+    /**
+     * 토큰 문자열(String)로 토큰 정보 조회
+     * 사용자가 헤더에 담아 보낸 '문자열'과 DB의 '문자열'을 비교
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * 특정 일시보다 이전(Before)인 만료 시간을 가진 토큰을 일괄 삭제합니다.
+     * @param now 현재 시간
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RefreshToken r WHERE r.expiryDate < :now")
+    void deleteByExpiryDateBefore(@Param("now")LocalDateTime now);
+}

--- a/src/main/java/com/cu2mber/authservice/auth/service/AuthService.java
+++ b/src/main/java/com/cu2mber/authservice/auth/service/AuthService.java
@@ -1,0 +1,10 @@
+package com.cu2mber.authservice.auth.service;
+
+import com.cu2mber.authservice.auth.dto.AccessToken;
+import com.cu2mber.authservice.auth.dto.TokenResponse;
+
+public interface AuthService {
+    TokenResponse createTokens(Long memberId, String role);
+
+    AccessToken refreshAccessToken(String refreshToken);
+}

--- a/src/main/java/com/cu2mber/authservice/auth/service/AuthService.java
+++ b/src/main/java/com/cu2mber/authservice/auth/service/AuthService.java
@@ -4,7 +4,9 @@ import com.cu2mber.authservice.auth.dto.AccessToken;
 import com.cu2mber.authservice.auth.dto.TokenResponse;
 
 public interface AuthService {
-    TokenResponse createTokens(Long memberId, String role);
+    TokenResponse createTokens(Long memberNo, String role);
 
     AccessToken refreshAccessToken(String refreshToken);
+
+    void logout(String refreshToken);
 }

--- a/src/main/java/com/cu2mber/authservice/auth/service/AuthService.java
+++ b/src/main/java/com/cu2mber/authservice/auth/service/AuthService.java
@@ -3,10 +3,34 @@ package com.cu2mber.authservice.auth.service;
 import com.cu2mber.authservice.auth.dto.AccessToken;
 import com.cu2mber.authservice.auth.dto.TokenResponse;
 
+/**
+ * 인증 및 토큰 관리 비즈니스 로직을 정의하는 서비스 인터페이스입니다.
+ * <p>Access Token과 Refresh Token의 발급, 갱신 및 로그아웃 처리를 담당합니다.</p>
+ */
 public interface AuthService {
+
+    /**
+     * 신규 토큰 세트(Access, Refresh)를 발급하고 Refresh Token을 저장합니다.
+     *
+     * @param memberNo 사용자 고유 번호
+     * @param role     사용자 권한
+     * @return 생성된 Access Token과 Refresh Token 정보를 담은 DTO
+     */
     TokenResponse createTokens(Long memberNo, String role);
 
+    /**
+     * 전달받은 Refresh Token의 유효성을 검증하여 새로운 Access Token을 발급합니다.
+     *
+     * @param refreshToken 클라이언트로부터 전달받은 리프레시 토큰
+     * @return 갱신된 Access Token 정보를 담은 DTO
+     * @throws RuntimeException 토큰이 존재하지 않거나 만료/위조된 경우 발생
+     */
     AccessToken refreshAccessToken(String refreshToken);
 
+    /**
+     * 로그아웃 요청 시 저장된 Refresh Token을 삭제합니다.
+     *
+     * @param refreshToken 무효화할 리프레시 토큰 문자열
+     */
     void logout(String refreshToken);
 }

--- a/src/main/java/com/cu2mber/authservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/cu2mber/authservice/auth/service/impl/AuthServiceImpl.java
@@ -1,17 +1,105 @@
 package com.cu2mber.authservice.auth.service.impl;
 
+import com.cu2mber.authservice.auth.domain.RefreshToken;
 import com.cu2mber.authservice.auth.dto.AccessToken;
 import com.cu2mber.authservice.auth.dto.TokenResponse;
+import com.cu2mber.authservice.auth.repository.RefreshTokenRepository;
 import com.cu2mber.authservice.auth.service.AuthService;
+import com.cu2mber.authservice.auth.util.JWTUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class AuthServiceImpl implements AuthService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JWTUtil jwtUtil;
+
+    /**
+     * 최초 로그인 시 Access Token과 Refresh Token을 생성하고, Refresh Token을 DB에 저장합니다.
+     *
+     * @param memberNo 사용자 고유 번호
+     * @param role     사용자 권한
+     * @return 생성된 토큰 세트 (Access, Refresh)
+     */
     @Override
-    public TokenResponse createTokens(Long memberId, String role) {
-        return null;
+    public TokenResponse createTokens(Long memberNo, String role) {
+        // JWTUtil을 사용하여 토큰 생성
+        String accessToken = jwtUtil.createJwt("access", memberNo, role, 1800000L); // 30분
+        String refreshToken = jwtUtil.createJwt("refresh", memberNo, role, 1209600000L); // 14일
+
+        // 생성된 Refresh Token을 RDS에 저장
+        saveRefreshToken(memberNo, refreshToken);
+
+        return new TokenResponse(accessToken, refreshToken);
     }
 
+    /**
+     * 리프레시 토큰의 유효성을 검증하고 새로운 액세스 토큰을 발급합니다.
+     *
+     * @param refreshToken 사용자가 전달한 리프레시 토큰
+     * @return 새로운 액세스 토큰
+     */
     @Override
     public AccessToken refreshAccessToken(String refreshToken) {
-        return null;
+        // DB에 해당 토큰이 존재하는지 확인
+        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 리프레시 토큰입니다."));
+
+        // JWT 자체 만료 확인
+        try {
+            if (jwtUtil.isTokenExpired(refreshToken)) {
+                throw new RuntimeException("리프레시 토큰이 만료되었습니다. 다시 로그인해주세요.");
+            }
+        } catch (Exception e) {
+            // 토큰 파싱 중 에러(위조 등)가 나도 예외 처리
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+
+        String userRole = jwtUtil.getRole(refreshToken);
+
+        // 유효하다면 새로운 Access Token 발급
+        String newAccessToken = jwtUtil.createJwt("access", storedToken.getMemberNo(), userRole, 1800000L);
+
+        return new AccessToken(newAccessToken);
+    }
+
+    /**
+     * 사용자의 리프레시 토큰을 삭제하여 로그아웃 처리를 수행합니다.
+     * <p>DB에서 토큰이 삭제되면 더 이상 액세스 토큰 갱신이 불가능해집니다.</p>
+     *
+     * @param refreshToken 삭제할 리프레시 토큰 문자열
+     */
+    @Override
+    public void logout(String refreshToken) {
+        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new RuntimeException("이미 로그아웃되었거나 존재하지 않는 토큰입니다."));
+
+        refreshTokenRepository.delete(storedToken);
+    }
+
+    /**
+     * 발급된 리프레시 토큰을 Amazon RDS에 저장합니다.
+     * <p>이미 해당 사용자의 토큰이 존재할 경우 새로운 토큰으로 업데이트합니다.</p>
+     *
+     * @param memberNo 사용자 고유 번호
+     * @param token    발급된 리프레시 토큰 문자열
+     */
+    private void saveRefreshToken(Long memberNo, String token) {
+        // 기존 토큰이 있다면 업데이트, 없으면 새로 생성
+        RefreshToken refreshToken = refreshTokenRepository.findByMemberNo(memberNo)
+                .map(existingToken -> {
+                    existingToken.updateToken(token, LocalDateTime.now().plusDays(14));
+                    return existingToken;
+                })
+                .orElse(new RefreshToken(memberNo, token, LocalDateTime.now().plusDays(14)));
+
+        refreshTokenRepository.save(refreshToken);
     }
 }

--- a/src/main/java/com/cu2mber/authservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/cu2mber/authservice/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,17 @@
+package com.cu2mber.authservice.auth.service.impl;
+
+import com.cu2mber.authservice.auth.dto.AccessToken;
+import com.cu2mber.authservice.auth.dto.TokenResponse;
+import com.cu2mber.authservice.auth.service.AuthService;
+
+public class AuthServiceImpl implements AuthService {
+    @Override
+    public TokenResponse createTokens(Long memberId, String role) {
+        return null;
+    }
+
+    @Override
+    public AccessToken refreshAccessToken(String refreshToken) {
+        return null;
+    }
+}

--- a/src/main/java/com/cu2mber/authservice/auth/util/JWTFilter.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/JWTFilter.java
@@ -1,0 +1,61 @@
+package com.cu2mber.authservice.auth.util;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 모든 요청에서 JWT 액세스 토큰의 유효성을 검증하는 필터입니다.
+ */
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1. 헤더에서 Authorization 토큰 추출
+        String authorization = request.getHeader("Authorization");
+
+        // 2. 토큰이 없거나 Bearer 형식이 아니면 다음 필터로 이동
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorization.split(" ")[1];
+
+        // 3. 토큰 만료 여부 확인
+        try {
+            if (jwtUtil.isTokenExpired(token)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        } catch (Exception e) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 4. 토큰에서 정보 추출 (memberNo, role)
+        Long memberNo = jwtUtil.getMemberNo(token);
+        String role = jwtUtil.getRole(token);
+
+        // 5. 스프링 시큐리티 전용 유저 객체 생성 및 인증 설정
+        // 여기서는 간단하게 사용자 번호와 권한만 저장합니다.
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(memberNo, null, null);
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/cu2mber/authservice/auth/util/JWTFilter.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/JWTFilter.java
@@ -6,27 +6,34 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
- * 모든 요청에서 JWT 액세스 토큰의 유효성을 검증하는 필터입니다.
+ * HTTP 요청 당 1회 실행되는 JWT 인증 필터
+ * 헤더의 Authorization 토큰을 검증하고 SecurityContext에 인증 정보를 등록합니다.
  */
 @RequiredArgsConstructor
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
 
+    /**
+     * 토큰 검증 로직 수행
+     * 만료된 토큰의 경우 401 에러와 메시지를 반환합니다.
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 1. 헤더에서 Authorization 토큰 추출
+        // 헤더에서 Authorization 토큰 추출
         String authorization = request.getHeader("Authorization");
 
-        // 2. 토큰이 없거나 Bearer 형식이 아니면 다음 필터로 이동
+        // 토큰이 없거나 Bearer 형식이 아니면 다음 필터로 이동
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             filterChain.doFilter(request, response);
             return;
@@ -34,28 +41,31 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String token = authorization.split(" ")[1];
 
-        // 3. 토큰 만료 여부 확인
+        // 토큰 만료 여부 확인
         try {
             if (jwtUtil.isTokenExpired(token)) {
-                filterChain.doFilter(request, response);
+                setResponse(response, "AccessToken has expired", HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
         } catch (Exception e) {
-            filterChain.doFilter(request, response);
+            setResponse(response, "Invalid Token", HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 
-        // 4. 토큰에서 정보 추출 (memberNo, role)
         Long memberNo = jwtUtil.getMemberNo(token);
         String role = jwtUtil.getRole(token);
 
-        // 5. 스프링 시큐리티 전용 유저 객체 생성 및 인증 설정
-        // 여기서는 간단하게 사용자 번호와 권한만 저장합니다.
         UsernamePasswordAuthenticationToken authToken =
-                new UsernamePasswordAuthenticationToken(memberNo, null, null);
+                new UsernamePasswordAuthenticationToken(memberNo, null, List.of(new SimpleGrantedAuthority(role)));
 
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
+    }
+
+    private void setResponse(HttpServletResponse response, String message, int status) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(status);
+        response.getWriter().println("{\"message\" : \"" + message + "\"}");
     }
 }

--- a/src/main/java/com/cu2mber/authservice/auth/util/JWTUtil.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/JWTUtil.java
@@ -9,6 +9,10 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+/**
+ * JWT 생성 및 검증 유틸리티
+ * HS256 알고리즘을 사용하여 토큰의 생명주기를 관리합니다.
+ */
 @Component
 public class JWTUtil {
 
@@ -22,7 +26,7 @@ public class JWTUtil {
     }
 
     /**
-     * JWT에서 memberNo(멤버번호) 추출
+     * JWT에서 사용자 정보(memberNo) 추출
      */
     public Long getMemberNo(String token) {
         return Jwts.parser()
@@ -46,7 +50,7 @@ public class JWTUtil {
     }
 
     /**
-     * JWT 만료 여부 확인
+     * 토큰 유효 기간 및 만료 여부 확인
      */
     public Boolean isTokenExpired(String token) {
         try {
@@ -64,14 +68,14 @@ public class JWTUtil {
     }
 
     /**
-     * JWT 생성 메서드
+     * 신규 액세스/리프레시 토큰 발급
      * @param category  토큰 종류 (access, refresh)
      * @param memberNo  사용자 고유 번호
      * @param role      사용자 권한
      * @param expiredMs 만료 시간 (밀리초)
      * @return 생성된 JWT 문자열
      */
-    public String createJwt(String category, Long memberNo, String role, Long expiredMs) {
+    public String createToken(String category, Long memberNo, String role, Long expiredMs) {
         return Jwts.builder()
                 .claim("category", category)
                 .claim("memberNo", memberNo)

--- a/src/main/java/com/cu2mber/authservice/auth/util/JWTUtil.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/JWTUtil.java
@@ -1,0 +1,73 @@
+package com.cu2mber.authservice.auth.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.Jwts;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private final SecretKey secretKey;
+
+    /**
+     * 생성자에서 application.properties에 저장된 SecretKey 값을 가져와 설정
+     */
+    public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    /**
+     * JWT에서 username 추출
+     */
+    public String getUsername(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getPayload()
+                .get("username", String.class);
+    }
+
+    /**
+     * JWT에서 role(권한) 추출
+     */
+    public String getRole(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    /**
+     * JWT 만료 여부 확인
+     */
+    public Boolean isTokenExpired(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getPayload()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    /**
+     * JWT 생성 메서드
+     * - memberId, role(권한), 만료 시간(expiredMs)을 포함한 JWT 발급
+     */
+    public String createJwt(Long memberId, String role, Long expiredMs) {
+        return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis())) // 발급 시간
+                .expiration(new Date(System.currentTimeMillis() + expiredMs)) // 만료 시간
+                .signWith(secretKey) // 비밀키를 사용하여 서명
+                .compact();
+    }
+}

--- a/src/main/java/com/cu2mber/authservice/auth/util/JWTUtil.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/JWTUtil.java
@@ -1,6 +1,6 @@
 package com.cu2mber.authservice.auth.util;
 
-import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import io.jsonwebtoken.Jwts;
@@ -26,45 +26,28 @@ public class JWTUtil {
     }
 
     /**
-     * JWT에서 사용자 정보(memberNo) 추출
+     * JWT를 파싱하여 내부의 Claims(Payload)를 추출합니다.
+     * <p>
+     * 이 메서드는 단 한 번의 호출로 다음과 같은 작업을 수행합니다.
+     * <ul>
+     * <li>토큰의 서명(Signature) 위조 여부 검증</li>
+     * <li>토큰의 유효 기간 및 만료 여부(Expiration) 자동 확인</li>
+     * </ul>
+     * 만약 토큰이 만료되었거나 구조가 유효하지 않을 경우, 예외를 발생시키므로
+     * 호출 측에서 추가적인 만료 체크 로직을 구현할 필요가 없습니다.
+     * </p>
+     *
+     * @param token 추출할 JWT 문자열
+     * @return 추출된 Claims(사용자 정보 및 권한 등)
+     * @throws io.jsonwebtoken.ExpiredJwtException 토큰의 유효 기간이 만료된 경우 발생
+     * @throws io.jsonwebtoken.JwtException 토큰이 변조되었거나 형식이 잘못된 경우 발생
      */
-    public Long getMemberNo(String token) {
+    public Claims getPayload(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
                 .parseClaimsJws(token)
-                .getPayload()
-                .get("memberNo", Long.class);
-    }
-
-    /**
-     * JWT에서 role(권한) 추출
-     */
-    public String getRole(String token) {
-        return Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getPayload()
-                .get("role", String.class);
-    }
-
-    /**
-     * 토큰 유효 기간 및 만료 여부 확인
-     */
-    public Boolean isTokenExpired(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getPayload()
-                    .getExpiration()
-                    .before(new Date());
-        } catch (ExpiredJwtException e) {
-            // 토큰이 만료된 경우
-            return true;
-        }
+                .getPayload();
     }
 
     /**

--- a/src/main/java/com/cu2mber/authservice/auth/util/TokenCleanupScheduler.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/TokenCleanupScheduler.java
@@ -1,0 +1,30 @@
+package com.cu2mber.authservice.auth.util;
+
+import com.cu2mber.authservice.auth.repository.RefreshTokenRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 매일 새벽 3시에 만료된 리프레시 토큰을 DB에서 일괄 삭제합니다.
+     * cron: "초 분 시 일 월 요일"
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupExpiredTokens() {
+        log.info("만료된 리프레시 토큰 삭제 스케줄러 실행");
+        refreshTokenRepository.deleteByExpiryDateBefore(LocalDateTime.now());
+        log.info("만료된 토큰 청소 완료");
+    }
+}

--- a/src/main/java/com/cu2mber/authservice/auth/util/TokenCleanupScheduler.java
+++ b/src/main/java/com/cu2mber/authservice/auth/util/TokenCleanupScheduler.java
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
+/**
+ * 리프레시 토큰 청소 스케줄러 클래스입니다.
+ * <p>데이터베이스의 무결성을 유지하고 불필요한 데이터를 정리하기 위해 정기적으로 만료된 토큰을 삭제합니다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/cu2mber/authservice/common/config/SecurityConfig.java
+++ b/src/main/java/com/cu2mber/authservice/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.cu2mber.authservice.common.config;
 
+import com.cu2mber.authservice.auth.util.JWTFilter;
 import com.cu2mber.authservice.auth.util.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -30,8 +31,7 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
 
                 .authorizeHttpRequests(auth -> auth
-                        // 토큰 발급 API(member-service가 호출함)와 토큰 갱신 API는 인증 없이 접근 허용
-                        .requestMatchers("/auth/issue", "/auth/refresh", "/signUp").permitAll()
+                        .requestMatchers("/auth/issue", "/auth/refresh", "/auth/logout").permitAll()
                         .anyRequest().authenticated())
 
                 // 갱신 요청 등을 보낼 때 이미 가진 토큰이 유효한지 확인하는 필터만 유지
@@ -42,7 +42,6 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // CORS 설정은 유지 (Gateway가 하지만, 서비스 레벨에서도 해두면 안전합니다)
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         return request -> {

--- a/src/main/java/com/cu2mber/authservice/common/config/SecurityConfig.java
+++ b/src/main/java/com/cu2mber/authservice/common/config/SecurityConfig.java
@@ -15,6 +15,10 @@ import org.springframework.web.cors.CorsConfigurationSource;
 
 import java.util.Collections;
 
+/**
+ * Spring Security 보안 설정 클래스
+ * JWT 기반 무상태(Stateless) 인증 및 CORS 설정을 관리합니다.
+ */
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -22,6 +26,11 @@ public class SecurityConfig {
 
     private final JWTUtil jwtUtil;
 
+    /**
+     * 보안 필터 체인 정의
+     * 허용 주소 설정 및 JWT 필터를 인증 프로세스 앞에 추가합니다.
+     * 추후, 로그인 안 해도 접근할 수 있는 경로 추가 예정
+     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -32,6 +41,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/issue", "/auth/refresh", "/auth/logout").permitAll()
+                        .requestMatchers( "/api/events/**", "/api/home/**", "/api/notices/**").permitAll()
                         .anyRequest().authenticated())
 
                 // 갱신 요청 등을 보낼 때 이미 가진 토큰이 유효한지 확인하는 필터만 유지
@@ -42,6 +52,11 @@ public class SecurityConfig {
         return http.build();
     }
 
+    /**
+     * CORS(Cross-Origin Resource Sharing) 설정
+     * <p>현재 로컬 개발 환경(http://localhost:3000)에 대해 모든 HTTP 메서드 및 헤더를 허용합니다.</p>
+     * <p>배포 환경으로 전환 시 허용 도메인(AllowedOrigins) 수정이 필요합니다.</p>
+     */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         return request -> {

--- a/src/main/java/com/cu2mber/authservice/common/config/SecurityConfig.java
+++ b/src/main/java/com/cu2mber/authservice/common/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package com.cu2mber.authservice.common.config;
+
+import com.cu2mber.authservice.auth.util.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JWTUtil jwtUtil;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+
+                .authorizeHttpRequests(auth -> auth
+                        // 토큰 발급 API(member-service가 호출함)와 토큰 갱신 API는 인증 없이 접근 허용
+                        .requestMatchers("/auth/issue", "/auth/refresh", "/signUp").permitAll()
+                        .anyRequest().authenticated())
+
+                // 갱신 요청 등을 보낼 때 이미 가진 토큰이 유효한지 확인하는 필터만 유지
+                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+    // CORS 설정은 유지 (Gateway가 하지만, 서비스 레벨에서도 해두면 안전합니다)
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration configuration = new CorsConfiguration();
+            configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000")); // 허용할 도메인
+            configuration.setAllowedMethods(Collections.singletonList("*")); // 모든 HTTP 메서드 허용
+            configuration.setAllowCredentials(true); // 인증 정보 포함 허용
+            configuration.setAllowedHeaders(Collections.singletonList("*")); // 모든 헤더 허용
+            configuration.setExposedHeaders(Collections.singletonList("Authorization")); // Authorization 헤더 노출
+            configuration.setMaxAge(1800L); // 30분 동안 캐싱
+            return configuration;
+        };
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=auth-service
+spring.profiles.active=dev

--- a/src/test/java/auth-test.http
+++ b/src/test/java/auth-test.http
@@ -1,0 +1,60 @@
+### 1. 최초 토큰 발급 (Issue)
+# 로그인 성공 시 member-service가 호출하는 로직
+POST http://localhost:8080/auth/issue
+Content-Type: application/json
+
+{
+  "memberNo": 1,
+  "role": "ROLE_USER"
+}
+
+> {%
+    // 응답에서 받은 토큰을 변수에 저장합니다.
+    client.global.set("access_token", response.body.accessToken);
+    client.global.set("refresh_token", response.body.refreshToken);
+%}
+
+
+### 2. 액세스 토큰 재발급 (Refresh)
+# Access Token이 만료되었을 때 Refresh Token으로 갱신
+POST http://localhost:8080/auth/refresh
+Refresh-Token: {{refresh_token}}
+
+> {%
+    client.global.set("access_token", response.body.accessToken);
+%}
+
+
+### 3. 로그아웃 (Logout)
+# DB에서 리프레시 토큰 삭제
+POST http://localhost:8080/auth/logout
+Refresh-Token: {{refresh_token}}
+
+
+### 4. 권한이 필요한 페이지 접근 테스트 (JWTFilter 확인)
+# 1번이나 2번 실행 후 변수에 저장된 access_token을 사용
+GET http://localhost:8080/any-secure-api
+Authorization: Bearer {{access_token}}
+
+
+### 5. 토큰 발급 (만료 시간이 1초인 토큰)
+POST http://localhost:8080/auth/issue
+Content-Type: application/json
+
+{
+  "memberNo": 2,
+  "role": "ROLE_USER"
+}
+
+> {%
+    client.global.set("expired_access_token", response.body.accessToken);
+%}
+
+
+### 6. 1초 기다린 후, 인증이 필요한 API 호출하기
+GET http://localhost:8080/any-secure-api
+Authorization: Bearer {{expired_access_token}}
+
+### 7. 로그인 안 해도 접근할 수 있는지 확인
+GET http://localhost:8081/api/events
+Accept: application/json


### PR DESCRIPTION
## 📌 관련 이슈

- close #1 

## ✨ 변경 내용

1. JWT 토큰 발급 및 관리 로직 구현
- Access Token: 30분 (보안 강화 및 세션 유지)
- Refresh Token: 14일 (사용자 편의성 및 재로그인 방지)
- Claim 구성: memberNo와 사용자 권한(ROLE_USER, ROLE_ADMIN, ROLE_GOV)을 포함하여 서비스 간 인가 처리 가능하도록 설계

2. 보안 필터 및 인가 설정
- Custom JWTFilter: 모든 요청에 대해 토큰의 유효성, 만료 여부를 검증하며 SecurityContext에 인증 정보 등록
- REST API 환경에 맞춰 CSRF, Form Login, Http Basic 비활성화
- Stateless 세션 정책 적용
- 비로그인 허용 경로 설정 (메인 페이지, 행사 목록 등)

3. Refresh Token 생명주기 관리
- 스케줄러 도입: 매일 새벽 3시, DB 내 만료된 Refresh Token을 자동 삭제하여 데이터 무결성 및 성능 최적화

향후 계획: 성능 향상 및 대규모 트래픽 대응을 위해 Redis로 전환 예정

## ✅ 체크리스트

- [x] 빌드 및 테스트가 모두 통과했나요?
- [x] merge할 branch를 확인했나요? (예: `develop` → `main`)
- [x] Assignee를 지정했나요?
- [x] 코드 리뷰어를 지정했나요? (필요 시)

## 📝 기타 참고 사항

- **Test Complete** : auth-test.http 파일을 통한 시나리오 테스트 완료 (토큰 발급 -> 만료 토큰 갱신 -> 로그아웃)
- **인프라** : 현재 토큰 저장을 위해 **Amazon RDS(MariaDB)를 사용 중**이며, 스케줄러를 통해 만료 데이터 관리
- **향후 계획** : 실제 배포 및 대규모 트래픽 대응 시, 성능 향상을 위해 Redis로 전환 예정
- **API 설정** : 서비스 연결 상태에 따라 비로그인 허용 경로를 지속적으로 업데이트할 예정
